### PR TITLE
Move channel information into gem

### DIFF
--- a/app/assets/javascripts/french_toast.js
+++ b/app/assets/javascripts/french_toast.js
@@ -1,5 +1,5 @@
 App.cable.subscriptions.create({
-  channel: "NotifierChannel"
+  channel: "FrenchToast::NotifierChannel"
 }, {
   received: function(content) {
     if (content !== undefined) {

--- a/app/channels/french_toast/notifier_channel.rb
+++ b/app/channels/french_toast/notifier_channel.rb
@@ -1,0 +1,11 @@
+module FrenchToast
+  class NotifierChannel < ApplicationCable::Channel
+    def subscribed
+      stream_from session_key
+    end
+
+    def unsubscribed
+      stop_all_streams
+    end
+  end
+end

--- a/spec/dummy/Procfile
+++ b/spec/dummy/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -p $PORT -C ./config/puma.rb
+worker: bundle exec rake jobs:work

--- a/spec/dummy/app/channels/notifier_channel.rb
+++ b/spec/dummy/app/channels/notifier_channel.rb
@@ -1,9 +1,0 @@
-class NotifierChannel < ApplicationCable::Channel
-  def subscribed
-    stream_from session_key
-  end
-
-  def unsubscribed
-    stop_all_streams
-  end
-end

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,6 +1,10 @@
-test:
+test: &default
   adapter: sqlite3
   database: snappy_test
   encoding: utf8
   min_messages: warning
   timeout: 5000
+
+development:
+  <<: *default
+  database: snappy_development

--- a/spec/dummy/config/secrets.yml
+++ b/spec/dummy/config/secrets.yml
@@ -1,5 +1,8 @@
 default: &default
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
+development:
+  <<: *default
+
 test:
   <<: *default


### PR DESCRIPTION
There were some configuration things still left in the dummy app that
prevent it from being an independent gem

Some possible work left to do:

* Move entire actioncable setup into frenchtoast
* At least separate out identification from main application

Other notes about branch

* Provide a development branch for dummy app so it stops complaining
  so much