### PR TITLE
Remove LastNotification when user subscribed to ActionCable

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+inherit_from:
+  - $HOME/.rubocop.yml
+
+Layout/IndentArray:
+  EnforcedStyle: consistent

--- a/french_toast.gemspec
+++ b/french_toast.gemspec
@@ -30,14 +30,15 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", "~> 5.0"
+  spec.add_dependency "redis", "~> 3.0"
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "capybara-webkit"
   spec.add_development_dependency "database_cleaner", "~> 1.6"
   spec.add_development_dependency "delayed_job_active_record", "~> 4.1"
   spec.add_development_dependency "jquery-rails", "~> 4.3"
   spec.add_development_dependency "puma"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "redis", "~> 3.0"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "rspec-rails", "~> 3.6"
   spec.add_development_dependency "sprockets", "~> 3.7"

--- a/spec/features/user_creates_an_article_html_spec.rb
+++ b/spec/features/user_creates_an_article_html_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature "user sees flash from created article" do
       expect(page).to have_css("p")
       expect(page).to have_content(processed_content)
     end
+    expect(FrenchToast::LastNotification.all).to be_empty
   end
 
   scenario "synchronously" do
@@ -50,5 +51,6 @@ RSpec.feature "user sees flash from created article" do
     visit root_path
 
     expect(page.html).to include processed_html
+    expect(FrenchToast::LastNotification.all).to be_empty
   end
 end

--- a/spec/lib/french_toast/notifier_spec.rb
+++ b/spec/lib/french_toast/notifier_spec.rb
@@ -30,5 +30,55 @@ RSpec.describe FrenchToast::Notifier do
       expect(ActionCable.server).
         to have_received(:broadcast).with(session_key, payload)
     end
+
+    context "when a user is connected via ActionCable" do
+      it "deletes the session's LastNotification" do
+        session_key = "a user's session key"
+        payload = "a payload to send"
+        fake_redis = instance_double(Redis)
+        allow(Redis).to receive(:new).and_return(fake_redis)
+        allow(fake_redis).to receive(:pubsub).
+          with("channels", "action_cable/*").
+          and_return([
+            "action_cable/#{session_key}",
+            "action_cable/asdfasdfasdgasdga",
+          ])
+        allow(ApplicationController).to receive(:render).and_return(payload)
+        allow(ActionCable.server).to receive(:broadcast)
+
+        described_class.new(session_key).
+          notify(:partial_name, locals: { foo: :bar })
+
+        expect(FrenchToast::LastNotification.where(session: session_key)).
+          to be_empty
+      end
+    end
+
+    context "when users is not connected via ActionCable" do
+      it "does not delete the session's LastNotification" do
+        session_key = "a user's session key"
+        payload = "a payload to send"
+        allow(ApplicationController).to receive(:render).and_return(payload)
+        allow(ActionCable.server).to receive(:broadcast)
+
+        described_class.new(session_key).
+          notify(:partial_name, locals: { foo: :bar })
+
+        expect(FrenchToast::LastNotification.find_by(session: session_key)).
+          to be_present
+      end
+    end
+
+    def subscribe_to_action_cable_channels(channel_names)
+      redis_channel_keys = channel_names.map do |channel_name|
+        "action_cable/#{channel_name}"
+      end
+      fake_redis = instance_double(Redis)
+      allow(Redis).to receive(:new).and_return(fake_redis)
+      allow(fake_redis).
+        to receive(:pubsub).
+        with("channels", "action_cable/*").
+        and_return(redis_channel_keys)
+    end
   end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,21 +1,21 @@
 RSpec.configure do |config|
- config.before(:suite) do
-   DatabaseCleaner.clean_with(:deletion)
- end
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:deletion)
+  end
 
- config.before(:each) do
-   DatabaseCleaner.strategy = :transaction
- end
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
 
- config.before(:each, js: true) do
-   DatabaseCleaner.strategy = :deletion
- end
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :deletion
+  end
 
- config.before(:each) do
-   DatabaseCleaner.start
- end
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
 
- config.after(:each) do
-   DatabaseCleaner.clean
- end
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
 end


### PR DESCRIPTION
Paired with: @tabfugnic 

This is a first step to monitor a users websocket connection so we can
determine if we need to run further actions after the fact. We don't
yet guarantee delivery by ActionCable, but this is a minimum
implementation needed to avoid double-delivery of notifications.